### PR TITLE
MAGETWO-63137: Fix Zend Mail vulnerability

### DIFF
--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -194,6 +194,18 @@ class Zend_Mail_Transport_Sendmail extends Zend_Mail_Transport_Abstract
             unset($headers['Subject']);
         }
 
+        // Sanitize the From header
+        if (isset($headers['From'])) {
+            $addressList = array_filter($headers['From'], function($key) {
+                return $key !== 'append';
+            }, ARRAY_FILTER_USE_KEY);
+            foreach ($addressList as $address) {
+                if (preg_match('/\\\"/', $address)) {
+                    throw new Zend_Mail_Transport_Exception('Potential code injection in From header');
+                }
+            }
+        }
+
         // Prepare headers
         parent::_prepareHeaders($headers);
 


### PR DESCRIPTION
## Scope

### Bug - P0
* [MAGETWO-63137](https://jira.corp.magento.com/browse/MAGETWO-63137) Fix Zend Mail vulnerability

### Bamboo CI builds

* [x] [M2 L1 (unit, JS, BAT, WEB API)](https://bamboo.corp.magento.com/browse/M2-L11094/latest)
* [x] [M2 L2 (integration)](https://bamboo.corp.magento.com/browse/M2-L21087/latest)
* [x] [M2 L3 (integrity, static legacy, static)](https://bamboo.corp.magento.com/browse/M2-L31122/latest)
* [x] [M2 L4 (PHP 5.5)](https://bamboo.corp.magento.com/browse/M2-L4429/latest)
* [x] [Functional Acceptance Tests](https://bamboo.corp.magento.com/browse/M2-FAT1163/latest)
* [ ] [Performance Acceptance Test](https://bamboo.corp.magento.com/browse/M2-PATN19/latest)
* [x] [Sample Data Tests](https://bamboo.corp.magento.com/browse/M2-SDT945/latest)
* [x] [Semantic Version Checker](https://bamboo.corp.magento.com/browse/SVC-SVC892/latest)
* [x] [Functional Unstable Tests](https://bamboo.corp.magento.com/browse/M2-FUT682/latest)
