### PR TITLE
Update composer.json to replace zendframework/zf1 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,8 @@
     },
     "archive": {
         "exclude": ["/demos", "/documentation", "/tests"]
+    },
+    "replace": {
+        "zendframework/zendframework1": "self.version"
     }
 }


### PR DESCRIPTION
Currently `magento/zendframework1` does not state that it is an replacement of `zendframework/zendframework1`. So if you have added another dependency which depends on any version of `zendframework/zendframework1`both magento's and zendframework's implementation of zf1 will be installed.

This may not sound like a problem first but composer is unable to choose which package it should use to get the requested classes. If you are generating optimized autoload files you best see this problem while you get hundreds of warnings. Which package is choosen seems to be deterministic on the dependencies you have, sometimes i got magento's one and sometimes zend's one:
```
Warning: Ambiguous class resolution, "Zend_Serializer" was found in both "/Users/tpetry/www/zf-fork-demo/vendor/zendframework/zendframework1/library/Zend/Serializer.php" and "/Users/tpetry/www/zf-fork-demo/vendor/magento/zendframework1/library/Zend/Serializer.php", the first will be used.
```