### PR TITLE
MAGECLOUD-2521: Use TLS 1.2

### DIFF
--- a/library/Zend/Http/Client/Adapter/Proxy.php
+++ b/library/Zend/Http/Client/Adapter/Proxy.php
@@ -297,10 +297,8 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
         // If all is good, switch socket to secure mode. We have to fall back
         // through the different modes
         $modes = array(
-            STREAM_CRYPTO_METHOD_TLS_CLIENT,
-            STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
-            STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
-            STREAM_CRYPTO_METHOD_SSLv2_CLIENT
+            // TODO: Add STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT in the future when it is supported by PHP
+            STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
         );
 
         $success = false;

--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -111,7 +111,8 @@ class Zend_Mail_Protocol_Imap
 
         if ($ssl === 'TLS') {
             $result = $this->requestAndResponse('STARTTLS');
-            $result = $result && stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+            // TODO: Add STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT in the future when it is supported by PHP
+            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
             if (!$result) {
                 /**
                  * @see Zend_Mail_Protocol_Exception

--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -112,7 +112,7 @@ class Zend_Mail_Protocol_Imap
         if ($ssl === 'TLS') {
             $result = $this->requestAndResponse('STARTTLS');
             // TODO: Add STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT in the future when it is supported by PHP
-            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
+            $result = $result && stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
             if (!$result) {
                 /**
                  * @see Zend_Mail_Protocol_Exception

--- a/library/Zend/Mail/Protocol/Pop3.php
+++ b/library/Zend/Mail/Protocol/Pop3.php
@@ -122,7 +122,8 @@ class Zend_Mail_Protocol_Pop3
 
         if ($ssl === 'TLS') {
             $this->request('STLS');
-            $result = stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+            // TODO: Add STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT in the future when it is supported by PHP
+            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
             if (!$result) {
                 /**
                  * @see Zend_Mail_Protocol_Exception

--- a/library/Zend/Mail/Protocol/Pop3.php
+++ b/library/Zend/Mail/Protocol/Pop3.php
@@ -123,7 +123,7 @@ class Zend_Mail_Protocol_Pop3
         if ($ssl === 'TLS') {
             $this->request('STLS');
             // TODO: Add STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT in the future when it is supported by PHP
-            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
+            $result = stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
             if (!$result) {
                 /**
                  * @see Zend_Mail_Protocol_Exception

--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -203,7 +203,8 @@ class Zend_Mail_Protocol_Smtp extends Zend_Mail_Protocol_Abstract
         if ($this->_secure == 'tls') {
             $this->_send('STARTTLS');
             $this->_expect(220, 180);
-            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
+            // TODO: Add STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT in the future when it is supported by PHP
+            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
                 /**
                  * @see Zend_Mail_Protocol_Exception
                  */


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2521

Since PHP version 5.6.7, `STREAM_CRYPTO_METHOD_TLS_CLIENT` changed to mean only TLS version 1.0.  Our use of this constant has caused these TLS connections to no longer work in a world where TLS 1.0 and 1.1 are now disabled for most services.  

In this pull request, I have replaced the use of that constant with STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT .  This will require version 1.2 of TLS.  

(Note that currently PCI only supports version 1.2 of TLS.  All other versions of TLS, and any version of SSL are required to be disabled by PCI.)

In the future, when TLS 1.3 is released, we will have to update this to also include STREAM_CRYPTO_METHOD_TLSv1_3._CLIENT


Testing/Verifying this patch:

Because I couldn't find an open or free TLS testing service, to test and verify this patch against SMTP, I made this phpunit file that can run to verify the functionality of this patch.  

All it does is try to Spark Post Mail's SMTP server, which doesn't support TLS 1.0, so it requires this patch.  It then tries to send an email, but fails, because I didn't want to put my real test account credentials in there.  So the test verifies that it fails because of Authentication error instead of failing because of TLS error.

To run it, download this file and add it to the root of your cloud environment. 
https://github.com/magento-cloud/magento-cloud-misc/blob/master/users/jacob/MAGECLOUD-2521/test-smtp-tls-sparkmail.php
Also, make sure to add php unit to your cloud environment by running this command.
`composer require phpunit/phpunit`
Then add it all and push.
`git add composer.lock composer.json test-smtp-tls-sparkmail.php ; git commit -m 'adding test for SMTP TLS' ; git push`
Once your cloud environment had redeployed, ssh into it and run 
`phpunit test-smtp-tls-sparkmail.php`
If you have the patch applied , it will succeed without failures.  If you don't have this patch applied, it will fail.

Note that this test will not work with PHP 7.2, because in PHP 7.2, they switched the TLS constants again, so it will silently connect with TLS 1.2 when using PHP 7.2.

Note that this test only tests SMTP and does not test the other affected protocols, POP3, IMAP, and HTTP proxy adaptor.
