### PR TITLE
Fix infinite lifetime in Zend_Cache_Backend_TwoLevels class

### DIFF
--- a/library/Zend/Cache/Backend/TwoLevels.php
+++ b/library/Zend/Cache/Backend/TwoLevels.php
@@ -501,7 +501,7 @@ class Zend_Cache_Backend_TwoLevels extends Zend_Cache_Backend implements Zend_Ca
             $fastLifetime = (int) ceil($lifetime / (11 - $priority));
         }
 
-        if ($maxLifetime >= 0 && $fastLifetime > $maxLifetime) {
+        if (($maxLifetime !== null) && $maxLifetime >= 0 && $fastLifetime > $maxLifetime) {
             return $maxLifetime;
         }
 


### PR DESCRIPTION
There is a bug in the `zf1/library/Zend/Cache/Backend/TwoLevels.php` class which is setting the lifetime for the fast cache `_getFastLifetime` function. 

It always set the lifetime to infinite (to `null` which is casted to `0`) regardless the `$lifetime` parameter because of the default value of the `$maxLifetime = null`. 

###The resposible condition part of the code as follow:
```
if ($maxLifetime >= 0 && $fastLifetime > $maxLifetime) {
            return $maxLifetime;
}
 ```
which will always evalute to true because of the default value of the `$maxLifetime = null`.

the issue faced while developing with memcached in Magento 2.2.5.

this is an bug in Zend framework 1 and it solved in early Zend framework 2
Links of the bug:
- https://framework.zend.com/issues/browse/ZF-11524
- https://github.com/zendframework/zf1/issues/503

but I solved same as how it solved in ZF2 :
- https://github.com/beberlei/zf2/blob/master/library/Zend/Cache/Backend/TwoLevels.php



 