### PR TITLE
MC-18944: ZendClient breaks when receiving an HTTP/2 response

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -182,7 +182,7 @@ class Zend_Http_Response
         $this->body = $body;
 
         // Set the HTTP version
-        if (! preg_match('|^\d\.\d$|', $version)) {
+        if (! preg_match('|^\d+(?:\.\d+)?$|', $version)) {
             #require_once 'Zend/Http/Exception.php';
             throw new Zend_Http_Exception("Invalid HTTP response version: $version");
         }
@@ -514,7 +514,7 @@ class Zend_Http_Response
         $last_header = null;
 
         foreach($lines as $index => $line) {
-            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+) [1-5]\d+#', $line)) {
+            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+)? [1-5]\d+#', $line)) {
                 // Status line; ignore
                 continue;
             }

--- a/tests/Zend/Http/ResponseTest.php
+++ b/tests/Zend/Http/ResponseTest.php
@@ -451,4 +451,39 @@ class Zend_Http_ResponseTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('imagetoolbar', $headers);
         $this->assertEmpty($headers['imagetoolbar']);
     }
+
+    /**
+     * Test that parsing HTTP2 response works.
+     */
+    public function testExtractHeadersShouldWorkWithHTTTP2()
+    {
+        $response = $this->readResponse('response_http_2');
+        $headers  = Zend_Http_Response::extractHeaders($response);
+
+        $this->assertArrayHasKey('connection', $headers);
+        $this->assertEquals('Keep-Alive', $headers['connection']);
+    }
+
+    /**
+     * Tests that version is validated properly when passed to the constructor.
+     *
+     * @param string $version
+     * @dataProvider constructorWithVersionDataProvider
+     */
+    public function testConstructorWithVersion($version)
+    {
+        try {
+            new Zend_Http_Response(200, array(), null, $version);
+        } catch (Zend_Http_Exception $e) {
+            $this->fail('Passing HTTP version ' . $version . ' generates an exception');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function constructorWithVersionDataProvider()
+    {
+        return array('1.0', '1.1', '2', '11.11');
+    }
 }

--- a/tests/Zend/Http/_files/response_http_2
+++ b/tests/Zend/Http/_files/response_http_2
@@ -1,0 +1,9 @@
+HTTP/2 200 OK
+Date: Wed, 05 Aug 2015 16:52:40 GMT
+Server: Apache
+Content-Length: 0
+Keep-Alive: timeout=15, max=100
+Connection: Keep-Alive
+Content-Type: text/html; charset=iso-8859-1
+
+


### PR DESCRIPTION
The issue is caused by the fact that the response result is checked by a regular expression that expects the Protocol version in the d.d format (for example, 1.0 or 1.1). For HTTP 2.0, the header returns a value in the format "HTTP/2 200 OK" without the decimal part. This results in an error. 