### PR TITLE
Avoid double semicolon in the generated DSN, which could cause MySql connection error.

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/library/Zend/Db/Adapter/Pdo/Abstract.php
@@ -72,7 +72,7 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
 
         // use all remaining parts in the DSN
         foreach ($dsn as $key => $val) {
-            $dsn[$key] = "$key=$val";
+            $dsn[$key] = trim("$key=$val", ';');
         }
 
         return $this->_pdoType . ':' . implode(';', $dsn);


### PR DESCRIPTION
I have a Magento 2 website which was migrated from Magento 1, and it has the following DB connection settings.

As can be seen from the code snippet below, it has a 'initStatements' field there and its value is a SQL statement with semicolon at the end.

This would cause an extra semicolon generated in the middle of DSN, so two semicolons in the string. Originally it works fine with my local MySql DB on that server, while it stops working when I migrate to DigitalOcean database service recently.

Just googled around, somebody else suffer the same problem too, and reported a Magento 2 bug at https://github.com/magento/magento2/issues/6526

I'm feeling this is not a special case only for me, more over it does take time to figure it out. So I'd like to suggest a code change here to get rid of this issue smoothly.

```
    'db' => [
        'table_prefix' => '',
        'connection' => [
            'default' => [
                'host' => 'my-db-server:25060',
                'dbname' => 'mydatabasename',
                'username' => 'dbuser',
                'password' => 'dbuserpassword',
                'active' => '1',
                'model' => 'mysql4',
                'engine' => 'innodb',
                'initStatements' => 'SET NAMES utf8;'
            ]
        ]
    ],
```