### PR TITLE
MC-29031: [Magento Cloud] Currency symbol not appearing in Arabic sto…

### DIFF
--- a/library/Zend/Locale/Data/ar_SA.xml
+++ b/library/Zend/Locale/Data/ar_SA.xml
@@ -29,7 +29,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>¤#0.00</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>


### PR DESCRIPTION
* [MC-29031](https://jira.corp.magento.com/browse/MC-29031) [Magento Cloud] Currency symbol not appearing in Arabic store view

Internal PR: https://github.com/magento-tsg-csl3/zf1/pull/1