### PR TITLE
Fix toCurrency to correctly strip currency sign

### DIFF
--- a/library/Zend/Currency.php
+++ b/library/Zend/Currency.php
@@ -194,12 +194,11 @@ class Zend_Currency
                                                                'precision'     => $options['precision']));
 
         if ($options['position'] !== self::STANDARD) {
-            $value = str_replace('¤', '', $value);
             $space = '';
-            if (iconv_strpos($value, ' ') !== false) {
-                $value = str_replace(' ', '', $value);
+            if (iconv_strpos($value, '¤ ') !== false || iconv_strpos($value, ' ¤') !== false) {
                 $space = ' ';
             }
+            $value = $this->_stripCurrencyPattern($value);
 
             if ($options['position'] == self::LEFT) {
                 $value = '¤' . $space . $value;
@@ -232,13 +231,32 @@ class Zend_Currency
 
                 default:
                     $sign = '';
-                    $value = str_replace(' ', '', $value);
+                    $value = $this->_stripCurrencyPattern($value);
                     break;
             }
         }
 
         $value = str_replace('¤', $sign, $value);
         return $value;
+    }
+
+    /**
+     * Strip the currency pattern an any sorrounding
+     * whitespace from a string value
+     *
+     * @param string $value
+     * @return string
+     */
+    private function _stripCurrencyPattern($value) {
+        if (iconv_strpos($value, '¤ ') === 0) {
+            return iconv_substr($value, 2);
+        }
+        else if (iconv_strpos($value, ' ¤') === iconv_strlen($value) - 2) {
+            return iconv_substr($value, 0, iconv_strlen($value) - 2);
+        }
+        else {
+            return str_replace('¤', '', $value);
+        }
     }
 
     /**

--- a/tests/Zend/CurrencyTest.php
+++ b/tests/Zend/CurrencyTest.php
@@ -303,6 +303,33 @@ class Zend_CurrencyTest extends PHPUnit_Framework_TestCase
         $this->assertSame('-₹ 3,00', $INR->toCurrency(-3));
     }
 
+    /*
+     * testing space separators
+     */
+    public function testSpaceSeparatorWithNoSymbol()
+    {
+        $HUF = new Zend_Currency('HUF','hu_HU');
+        $EUR = new Zend_Currency('USD','de_AT');
+        $USD = new Zend_Currency('USD','en_US');
+
+        $options = array(
+            'display' => Zend_Currency::NO_SYMBOL
+        );
+        $this->assertSame('53 292,18', $HUF->toCurrency(53292.18, $options));
+        $this->assertSame('53.292,18', $EUR->toCurrency(53292.18, $options));
+        $this->assertSame('53,292.18', $USD->toCurrency(53292.18, $options));
+
+        $options['position'] = Zend_Currency::LEFT;
+        $this->assertSame('53 292,18', $HUF->toCurrency(53292.18, $options));
+        $this->assertSame('53.292,18', $EUR->toCurrency(53292.18, $options));
+        $this->assertSame('53,292.18', $USD->toCurrency(53292.18, $options));
+
+        $options['position'] = Zend_Currency::RIGHT;
+        $this->assertSame('53 292,18', $HUF->toCurrency(53292.18, $options));
+        $this->assertSame('53.292,18', $EUR->toCurrency(53292.18, $options));
+        $this->assertSame('53,292.18', $USD->toCurrency(53292.18, $options));
+    }
+
     /**
      * testing setFormat
      *


### PR DESCRIPTION
Zend_Currency::toCurrency has an option to return the currency formatted without the currency sign. It should also trim any whitespaces before or after the currency sign. However it did strip every whitespace from the formatted string, even if the given locale uses spaces to separate thousands groups. For example when using the Hungarian locale instead of `12 345` it did return `12345`.

This can

This commit fixes this error, and adds some test around it.
