### PR TITLE
Fix broken YAML parsing

### DIFF
--- a/library/Zend/Config/Yaml.php
+++ b/library/Zend/Config/Yaml.php
@@ -279,6 +279,18 @@ class Zend_Config_Yaml extends Zend_Config
     }
 
     /**
+     * @param array $array
+     * @return array|bool
+     */
+    protected static function _each(array &$array)
+    {
+        $key = key($array);
+        $current = current($array);
+        next($array);
+        return is_null($key) ? false : [$key, $current, 'key' => $key, 'value' => $current];
+    }
+
+    /**
      * Service function to decode YAML
      *
      * @param  int $currentIndent Current indent level
@@ -289,7 +301,7 @@ class Zend_Config_Yaml extends Zend_Config
     {
         $config   = array();
         $inIndent = false;
-        foreach ($line as $n => $line) {
+        while (list($n, $line) = self::_each($lines)) {
             $lineno = $n + 1;
 
             $line = rtrim(preg_replace("/#.*$/", "", $line));


### PR DESCRIPTION
Signed-off-by: halfpastfouram <bobkruithof@gmail.com>

Fixes a bug reported in #21 that was introduced by e6487d5d7f7a2e7d1b7e71669011a39ebd1fe1f9 resulting in a broken parser.

No single YAML file can be parsed so I fixed it by emulating PHP's `each` functionality without having to change the existing code in the loop.