### PR TITLE
fix(oauth): sort parameters in a standard way as per the specs

### DIFF
--- a/library/Zend/Oauth/Signature/SignatureAbstract.php
+++ b/library/Zend/Oauth/Signature/SignatureAbstract.php
@@ -167,7 +167,7 @@ abstract class Zend_Oauth_Signature_SignatureAbstract
     protected function _toByteValueOrderedQueryString(array $params)
     {
         $return = array();
-        uksort($params, 'strnatcmp');
+        ksort($params);
         foreach ($params as $key => $value) {
             if (is_array($value)) {
                 natsort($value);


### PR DESCRIPTION
This PR is similar to https://github.com/OpenMage/magento-lts/pull/721
Please read the full description there.

## TL;DR

Parameters must be "sorted by name, using lexicographical byte value ordering" (from [Oauth specs](https://oauth.net/core/1.0a/#rfc.section.9.1.1)) which is incorrect if using `natsort`.

Magento is not able to validate signatures for requests with parameters such as `/rest/V1/foo?keys[0]=test1&keys[1]=test2&keys[2]=test3&keys[3]=test4&keys[4]=test5&keys[5]=test6&keys[6]=test7&keys[7]=test8&keys[8]=test9&keys[9]=test10&keys[10]=test11` as it will consider that `keys[10]` goes after `keys[9]` whereas it should be ordered between `keys[1]` and `keys[2]`.