### PR TITLE
Fix invalid comparison operator on PHP 8.0

### DIFF
--- a/library/Zend/Xml/Security.php
+++ b/library/Zend/Xml/Security.php
@@ -167,10 +167,10 @@ class Zend_Xml_Security
     public static function isPhpFpm()
     {
         $isVulnerableVersion = (
-            version_compare(PHP_VERSION, '5.5.22', 'lt')
+            version_compare(PHP_VERSION, '5.5.22', '<')
             || (
-                version_compare(PHP_VERSION, '5.6', 'gte')
-                && version_compare(PHP_VERSION, '5.6.6', 'lt')
+                version_compare(PHP_VERSION, '5.6', '>=')
+                && version_compare(PHP_VERSION, '5.6.6', '<')
             )
         );
 


### PR DESCRIPTION
fixes "PHP Fatal error:  Uncaught ValueError: version_compare(): Argument #3 ($operator) must be a valid comparison operator" error message on PHP 8.0