### PR TITLE
Fix php 8.1 deprecation issues caused by preg_replace error

### DIFF
--- a/library/Zend/Db/Statement.php
+++ b/library/Zend/Db/Statement.php
@@ -198,6 +198,12 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
             $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql);
         }
 
+        if ($sql === null) {
+            // this preg_replace may return NULL in case of error (PREG_BACKTRACK_LIMIT_ERROR).
+            // In that case the result of this method will be an empty string.
+            return '';
+        }
+
         // get a version of the SQL statement with all quoted
         // values and delimited identifiers stripped out
         // remove "foo\"bar"


### PR DESCRIPTION
Hotfix for the deprecation warning on PHP 8.1 (passing null to preg_replace), which is caused by the previous preg_replace returning NULL (due to PREG_BACKTRACK_LIMIT_ERROR).

This fix should be rolled back after we fix the regular expression (L198).
The main issue described here:
(TBD Here will be the link to the ticket)