### PR TITLE
Update Abstract.php

### DIFF
--- a/library/Zend/Mail/Storage/Abstract.php
+++ b/library/Zend/Mail/Storage/Abstract.php
@@ -215,7 +215,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
      *
      * @return   int
      */
-     public function count()
+     public function count(): int
      {
         return $this->countMessages();
      }


### PR DESCRIPTION
Fix issue in php 8.1

- Return type of Zend_Mail_Storage_Abstract::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in magento/vendor/magento/zendframework1/library/Zend/Mail/Storage/Abstract.php:218