### PR TITLE
AC-2892:Class magento/zendframework1/library/Zend/Pdf/NameTree.php no…

### DIFF
--- a/library/Zend/Pdf/Element/Reference.php
+++ b/library/Zend/Pdf/Element/Reference.php
@@ -83,13 +83,17 @@ class Zend_Pdf_Element_Reference extends Zend_Pdf_Element
      * Object constructor:
      *
      * @param integer $objNum
-     * @param integer $genNum
      * @param Zend_Pdf_Element_Reference_Context $context
      * @param Zend_Pdf_ElementFactory $factory
+     * @param int $genNum
      * @throws Zend_Pdf_Exception
      */
-    public function __construct($objNum, $genNum = 0, Zend_Pdf_Element_Reference_Context $context, Zend_Pdf_ElementFactory $factory)
-    {
+    public function __construct(
+        $objNum,
+        Zend_Pdf_Element_Reference_Context $context,
+        Zend_Pdf_ElementFactory $factory,
+        $genNum = 0
+    ){
         if ( !(is_integer($objNum) && $objNum > 0) ) {
             #require_once 'Zend/Pdf/Exception.php';
             throw new Zend_Pdf_Exception('Object number must be positive integer');

--- a/library/Zend/Pdf/Element/Reference.php
+++ b/library/Zend/Pdf/Element/Reference.php
@@ -82,18 +82,23 @@ class Zend_Pdf_Element_Reference extends Zend_Pdf_Element
     /**
      * Object constructor:
      *
-     * @param integer $objNum
+     * @param int $objNum
+     * @param int $genNum
      * @param Zend_Pdf_Element_Reference_Context $context
      * @param Zend_Pdf_ElementFactory $factory
-     * @param int $genNum
      * @throws Zend_Pdf_Exception
      */
     public function __construct(
         $objNum,
+        $genNum,
         Zend_Pdf_Element_Reference_Context $context,
-        Zend_Pdf_ElementFactory $factory,
-        $genNum = 0
+        Zend_Pdf_ElementFactory $factory
     ){
+        // This was changed as PHP8 errors out if there's an optional parameter before a required param
+        if (empty($genNum)) {
+            $genNum = 0;
+        }
+
         if ( !(is_integer($objNum) && $objNum > 0) ) {
             #require_once 'Zend/Pdf/Exception.php';
             throw new Zend_Pdf_Exception('Object number must be positive integer');

--- a/library/Zend/Pdf/NameTree.php
+++ b/library/Zend/Pdf/NameTree.php
@@ -85,68 +85,71 @@ class Zend_Pdf_NameTree implements ArrayAccess, Iterator, Countable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->_items);
     }
 
-
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return next($this->_items);
     }
 
-
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_items);
     }
 
-
-    public function valid() {
+    #[\ReturnTypeWillChange]
+    public function valid()
+    {
         return current($this->_items)!==false;
     }
 
-
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_items);
     }
 
-
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->_items);
     }
 
-
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_items[$offset];
     }
 
-
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($offset === null) {
-            $this->_items[]        = $value;
+            $this->_items[] = $value;
         } else {
             $this->_items[$offset] = $value;
         }
     }
 
-
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_items[$offset]);
     }
 
-
+    #[\ReturnTypeWillChange]
     public function clear()
     {
         $this->_items = array();
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_items);

--- a/library/Zend/Pdf/StringParser.php
+++ b/library/Zend/Pdf/StringParser.php
@@ -514,7 +514,12 @@ class Zend_Pdf_StringParser
             return null;
         }
 
-        $ref = new Zend_Pdf_Element_Reference((int)$objNum, (int)$genNum, $this->_context, $this->_objFactory->resolve());
+        $ref = new Zend_Pdf_Element_Reference(
+            (int)$objNum,
+            $this->_context,
+            $this->_objFactory->resolve(),
+            (int)$genNum
+        );
 
         return $ref;
     }

--- a/library/Zend/Pdf/StringParser.php
+++ b/library/Zend/Pdf/StringParser.php
@@ -516,9 +516,9 @@ class Zend_Pdf_StringParser
 
         $ref = new Zend_Pdf_Element_Reference(
             (int)$objNum,
+            (int)$genNum,
             $this->_context,
-            $this->_objFactory->resolve(),
-            (int)$genNum
+            $this->_objFactory->resolve()
         );
 
         return $ref;


### PR DESCRIPTION
…t compatible with PHP 8.1

    - Fixed PHP8 error - ArrayAccess: Uncaught Exception: Deprecated Functionality: Return type of Zend_Pdf_NameTree::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/magento/zendframework1/library/Zend/Pdf/NameTree.php
    - Fixed PHP8 error - Deprecated Functionality: Optional parameter $genNum declared before required parameter $factory is implicitly treated as a required parameter in vendor/magento/zendframework1/library/Zend/Pdf/Element/Reference.php on line 91
    
Fixes: https://github.com/magento/magento2/issues/35335
Fixes: https://github.com/magento/zf1/issues/44