### PR TITLE
Fix php 8.1 compatibility

### DIFF
--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -202,7 +202,7 @@ class Zend_Registry extends ArrayObject
      * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($index)
+    public function offsetExists($index) : bool
     {
         return array_key_exists($index, $this);
     }


### PR DESCRIPTION
There is not defined return value as is required from parent definition.